### PR TITLE
Reuse WebSocket connection and close them when disconnecting

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types"],
+  "include": [
+    "src",
+    "types"
+  ],
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "importHelpers": true,
     // output .d.ts declaration files for consumers
     "declaration": true,
@@ -31,5 +37,6 @@
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
+    "outDir": "dist",
   }
 }


### PR DESCRIPTION
Currently, a new WebSocket connection is created for each request (and never closed), this means that if we request 100 decrypts to a relay, we are opening 100 WebSocket connections with the relay.

This PR adds the following:
* Open only 2 WebSocket connections
* Close WebSocket connections when disconnecting
